### PR TITLE
Add auto-refreshing joke box

### DIFF
--- a/components/JokeBox.js
+++ b/components/JokeBox.js
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+export default function JokeBox() {
+  const [joke, setJoke] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchJoke() {
+      try {
+        const res = await fetch('https://official-joke-api.appspot.com/jokes/random');
+        if (!res.ok) return;
+        const data = await res.json();
+        if (isMounted) setJoke(data);
+      } catch (err) {
+        console.error('Error fetching joke:', err);
+      }
+    }
+
+    fetchJoke();
+    const id = setInterval(fetchJoke, 5000);
+
+    return () => {
+      isMounted = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (!joke) {
+    return (
+      <div className="joke-box">
+        Loading...
+        <style jsx>{`
+          .joke-box {
+            border: 1px solid #e5e7eb;
+            border-radius: 0.5rem;
+            padding: 1rem;
+            margin: 2rem auto;
+            max-width: 600px;
+            background: #fff;
+            text-align: center;
+          }
+        `}</style>
+      </div>
+    );
+  }
+
+  return (
+    <div className="joke-box">
+      <p>{joke.setup}</p>
+      <p><em>{joke.punchline}</em></p>
+      <style jsx>{`
+        .joke-box {
+          border: 1px solid #e5e7eb;
+          border-radius: 0.5rem;
+          padding: 1rem;
+          margin: 2rem auto;
+          max-width: 600px;
+          background: #fff;
+          text-align: center;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import JokeBox from '../components/JokeBox';
 
 const projects = [
   {
@@ -72,6 +73,7 @@ export default function Home() {
           </a>
         </div>
       </header>
+      <JokeBox />
 
       <section className="projects">
         <h2>Projects</h2>


### PR DESCRIPTION
## Summary
- fetch random jokes from Official Joke API every 5 seconds
- display a styled joke box on the homepage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa7cc836ac8332bd16f365c9ed8bc6