### PR TITLE
style: add modern gradient and shadow to JokeBox

### DIFF
--- a/components/JokeBox.js
+++ b/components/JokeBox.js
@@ -32,13 +32,18 @@ export default function JokeBox() {
         Loading...
         <style jsx>{`
           .joke-box {
-            border: 1px solid #e5e7eb;
-            border-radius: 0.5rem;
-            padding: 1rem;
             margin: 2rem auto;
             max-width: 600px;
-            background: #fff;
+            padding: 2rem;
+            border-radius: 1rem;
             text-align: center;
+            color: #fff;
+            background: linear-gradient(135deg, #6366f1 0%, #ec4899 100%);
+            box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1),
+              0 4px 6px rgba(0, 0, 0, 0.05);
+          }
+          .joke-box p {
+            margin: 0.5rem 0;
           }
         `}</style>
       </div>
@@ -51,13 +56,18 @@ export default function JokeBox() {
       <p><em>{joke.punchline}</em></p>
       <style jsx>{`
         .joke-box {
-          border: 1px solid #e5e7eb;
-          border-radius: 0.5rem;
-          padding: 1rem;
           margin: 2rem auto;
           max-width: 600px;
-          background: #fff;
+          padding: 2rem;
+          border-radius: 1rem;
           text-align: center;
+          color: #fff;
+          background: linear-gradient(135deg, #6366f1 0%, #ec4899 100%);
+          box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1),
+            0 4px 6px rgba(0, 0, 0, 0.05);
+        }
+        .joke-box p {
+          margin: 0.5rem 0;
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Summary
- give the JokeBox component a colorful gradient background and modern shadow
- adjust spacing and text color for a cleaner design

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa7fb1323c8332aaf3742be2b1f369