### PR TITLE
fix: update Groq base URL and default model

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -2,10 +2,8 @@ import { useState } from 'react';
 
 export default function Home() {
   const [apiKey, setApiKey] = useState('');
-  const [baseUrl, setBaseUrl] = useState(
-    'https://api.groq.com/openai/v1/chat/completions'
-  );
-  const [model, setModel] = useState('mixtral-8x7b');
+  const [baseUrl, setBaseUrl] = useState('https://api.groq.com/openai/v1');
+  const [model, setModel] = useState('llama-3.3-70b-versatile');
   const [input, setInput] = useState('');
   const [messages, setMessages] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -17,7 +15,8 @@ export default function Home() {
     setInput('');
     setLoading(true);
     try {
-      const res = await fetch(baseUrl, {
+      const endpoint = `${baseUrl.replace(/\/$/, '')}/chat/completions`;
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -29,6 +28,9 @@ export default function Home() {
         }),
       });
       const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error?.message || 'Request failed');
+      }
       const content =
         data.choices?.[0]?.message?.content || 'No response from model.';
       setMessages([...newMessages, { role: 'assistant', content }]);


### PR DESCRIPTION
## Summary
- use `https://api.groq.com/openai/v1` as default base URL
- switch default model to `llama-3.3-70b-versatile`
- build chat endpoint with `/chat/completions` and surface API errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aae5c6093c833281fd1c7c3682249d