### PR TITLE
feat: enhance chatbot UI with modern styling

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -93,49 +93,148 @@ export default function Home() {
             <strong>{m.role === 'user' ? 'You' : 'Bot'}:</strong> {m.content}
           </div>
         ))}
+        {loading && (
+          <div className="message assistant typing">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        )}
       </div>
       <textarea
         value={input}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={handleKey}
         placeholder="Type your message..."
+        className="inputArea"
       />
-      <button onClick={sendMessage} disabled={loading}>
+      <button onClick={sendMessage} disabled={loading} className={loading ? 'loading' : ''}>
         {loading ? 'Sending...' : 'Send'}
       </button>
       <style jsx>{`
+        :global(body) {
+          background: #f3f4f6;
+        }
         .container {
           max-width: 600px;
           margin: 2rem auto;
           font-family: sans-serif;
           display: flex;
           flex-direction: column;
+          background: #fff;
+          padding: 2rem;
+          border-radius: 1rem;
+          box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1),
+            0 4px 6px rgba(0, 0, 0, 0.05);
         }
         .apiKeyInput,
         .baseUrlInput,
-        .modelSelect {
+        .modelSelect,
+        .inputArea {
           margin-bottom: 1rem;
           padding: 0.5rem;
+          border: 1px solid #d1d5db;
+          border-radius: 0.5rem;
+          outline: none;
+        }
+        .apiKeyInput:focus,
+        .baseUrlInput:focus,
+        .modelSelect:focus,
+        .inputArea:focus {
+          border-color: #3b82f6;
+          box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
         }
         .chat {
-          border: 1px solid #ccc;
+          border: 1px solid #e5e7eb;
           padding: 1rem;
           height: 300px;
           overflow-y: auto;
           margin-bottom: 1rem;
+          background: #f9fafb;
+          border-radius: 0.5rem;
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+          box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
         }
         .message {
-          margin-bottom: 0.5rem;
+          padding: 0.5rem 1rem;
+          border-radius: 1rem;
+          max-width: 80%;
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+          animation: fadeIn 0.3s ease;
         }
-        textarea {
+        .message.user {
+          align-self: flex-end;
+          background: #3b82f6;
+          color: #fff;
+          border-bottom-right-radius: 0.25rem;
+        }
+        .message.assistant {
+          align-self: flex-start;
+          background: #e5e7eb;
+          color: #1f2937;
+          border-bottom-left-radius: 0.25rem;
+        }
+        .message.typing {
+          display: flex;
+        }
+        .message.typing span {
+          width: 8px;
+          height: 8px;
+          background: #9ca3af;
+          border-radius: 50%;
+          margin-right: 4px;
+          animation: blink 1.4s infinite both;
+        }
+        .message.typing span:nth-child(2) {
+          animation-delay: 0.2s;
+        }
+        .message.typing span:nth-child(3) {
+          animation-delay: 0.4s;
+        }
+        .inputArea {
           resize: none;
           height: 80px;
-          margin-bottom: 1rem;
-          padding: 0.5rem;
         }
         button {
           align-self: flex-end;
           padding: 0.5rem 1rem;
+          background: #3b82f6;
+          color: #fff;
+          border: none;
+          border-radius: 0.5rem;
+          cursor: pointer;
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+          transition: background 0.3s, transform 0.3s;
+        }
+        button:hover {
+          background: #2563eb;
+        }
+        button:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+            transform: translateY(10px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        @keyframes blink {
+          0% {
+            opacity: 0.2;
+          }
+          20% {
+            opacity: 1;
+          }
+          100% {
+            opacity: 0.2;
+          }
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Summary
- modernize chat layout with container, bubble styles, and shadows
- add animated typing indicator and message fade-in

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aae9baf9748332b4431b46805d49e4